### PR TITLE
Paint selection colour after rendering the text

### DIFF
--- a/editor.go
+++ b/editor.go
@@ -254,10 +254,10 @@ func (e *Editor) layout(gtx layout.Context) layout.Dimensions {
 	}
 
 	if e.Len() > 0 {
-		e.paintSelection(gtx, selectColor)
+		e.paintText(gtx, textMaterial)
 		e.paintLineHighlight(gtx, lineColor)
 		e.text.HighlightMatchingBrackets(gtx, selectColor.Op(gtx.Ops))
-		e.paintText(gtx, textMaterial)
+		e.paintSelection(gtx, selectColor)
 	}
 	if gtx.Enabled() {
 		e.paintCaret(gtx, textMaterial)


### PR DESCRIPTION
Hi, 

I have noticed that when editor background colour is set based on style, the selection colour is not rendered correctly. 

This change will fix the issue for my use case but not 100% sure if it's the right fix for all. 

Images from before and after the fix:

Before:
<img width="432" height="229" alt="Screenshot 2025-11-01 at 11 30 25" src="https://github.com/user-attachments/assets/9eaa6ed7-4fca-4eba-86d0-e575eb7671d1" />

After:
<img width="432" height="229" alt="Screenshot 2025-11-01 at 11 30 53" src="https://github.com/user-attachments/assets/2bdc23d4-171e-4b0f-8ca5-bcb1b008a60f" />
